### PR TITLE
Use '§' character to indicate references to sections/paragraphs/whatever

### DIFF
--- a/classes/cthit.cls
+++ b/classes/cthit.cls
@@ -53,6 +53,10 @@
   \end{list}
 }
 
+\DeclareDocumentCommand \paragraphref {m}{%
+    §\ref{#1}%
+}
+
  %mbox to prevent line-breaking on name
 \DeclareDocumentCommand \HUBBEN {}{\mbox{Hubben}}
 

--- a/stadga/allmant.tex
+++ b/stadga/allmant.tex
@@ -10,7 +10,7 @@ Teknologsektionen har som uppdrag att verka för sammanhållning mellan medlemma
 
 \subsection{Medlemmar}
 
-Medlem i teknologsektionen är den som är eller har varit inskriven vid utbildningsprogrammet Informationsteknik vid Chalmers och betalar sektionsavgift. Medlem är även studerande vid Chalmers efter erlagd sektionsavgift och godkännande från teknologsektionens styrelse. Därutöver kan teknologsektionen utse hedersmedlemmar, enligt §\ref{sec:hedersmedlemmar}.
+Medlem i teknologsektionen är den som är eller har varit inskriven vid utbildningsprogrammet Informationsteknik vid Chalmers och betalar sektionsavgift. Medlem är även studerande vid Chalmers efter erlagd sektionsavgift och godkännande från teknologsektionens styrelse. Därutöver kan teknologsektionen utse hedersmedlemmar, enligt \paragraphref{sec:hedersmedlemmar}.
 
 \subsection{Verksamhetsår}
 Teknologsektionens verksamhetsår löper från och med 1:a juli till och med 30:e juni påföljande år.

--- a/stadga/allmant.tex
+++ b/stadga/allmant.tex
@@ -10,7 +10,7 @@ Teknologsektionen har som uppdrag att verka för sammanhållning mellan medlemma
 
 \subsection{Medlemmar}
 
-Medlem i teknologsektionen är den som är eller har varit inskriven vid utbildningsprogrammet Informationsteknik vid Chalmers och betalar sektionsavgift. Medlem är även studerande vid Chalmers efter erlagd sektionsavgift och godkännande från teknologsektionens styrelse. Därutöver kan teknologsektionen utse hedersmedlemmar, enligt \$\ref{sec:hedersmedlemmar}
+Medlem i teknologsektionen är den som är eller har varit inskriven vid utbildningsprogrammet Informationsteknik vid Chalmers och betalar sektionsavgift. Medlem är även studerande vid Chalmers efter erlagd sektionsavgift och godkännande från teknologsektionens styrelse. Därutöver kan teknologsektionen utse hedersmedlemmar, enligt §\ref{sec:hedersmedlemmar}.
 
 \subsection{Verksamhetsår}
 Teknologsektionens verksamhetsår löper från och med 1:a juli till och med 30:e juni påföljande år.

--- a/stadga/revision.tex
+++ b/stadga/revision.tex
@@ -14,7 +14,7 @@ Räkenskaper och övriga handlingar skall vara revisorerna tillhanda senast 15 l
 \subsection{Åligganden}
 
 \subsubsection{Åligganden}
-Det åligger revisorerna att korrekt anslå, enligt \ref{sec:protokoll:anslagning}revisionsberättelser senast tre läsdagar före ordinarie sektionsmöte.
+Det åligger revisorerna att korrekt anslå, enligt §\ref{sec:protokoll:anslagning}revisionsberättelser senast tre läsdagar före ordinarie sektionsmöte.
 
 \subsubsection{Revisionsberättelsen}
 Revisionsberättelsen skall innehålla yttrande ifråga om ansvarsfrihet för berörda personer.

--- a/stadga/revision.tex
+++ b/stadga/revision.tex
@@ -14,7 +14,7 @@ Räkenskaper och övriga handlingar skall vara revisorerna tillhanda senast 15 l
 \subsection{Åligganden}
 
 \subsubsection{Åligganden}
-Det åligger revisorerna att korrekt anslå, enligt §\ref{sec:protokoll:anslagning}revisionsberättelser senast tre läsdagar före ordinarie sektionsmöte.
+Det åligger revisorerna att korrekt anslå, enligt \paragraphref{sec:protokoll:anslagning}revisionsberättelser senast tre läsdagar före ordinarie sektionsmöte.
 
 \subsubsection{Revisionsberättelsen}
 Revisionsberättelsen skall innehålla yttrande ifråga om ansvarsfrihet för berörda personer.

--- a/stadga/sektionsmote.tex
+++ b/stadga/sektionsmote.tex
@@ -74,7 +74,7 @@ Sektionsmötet har följande åligganden:
 \subsection{Beslutförhet}
 
 \subsubsection{Beslutsmässighet}
-Sektionsmötet är beslutsmässigt om mötet är behörigt utlyst enligt §\ref{sec:utlysande}
+Sektionsmötet är beslutsmässigt om mötet är behörigt utlyst enligt §\ref{sec:utlysande}.
 
 \subsubsection{Krav}
 Beslut kräver att minst x medlemmar är närvarande. \\

--- a/stadga/sektionsmote.tex
+++ b/stadga/sektionsmote.tex
@@ -74,7 +74,7 @@ Sektionsmötet har följande åligganden:
 \subsection{Beslutförhet}
 
 \subsubsection{Beslutsmässighet}
-Sektionsmötet är beslutsmässigt om mötet är behörigt utlyst enligt \ref{sec:utlysande}
+Sektionsmötet är beslutsmässigt om mötet är behörigt utlyst enligt §\ref{sec:utlysande}
 
 \subsubsection{Krav}
 Beslut kräver att minst x medlemmar är närvarande. \\
@@ -115,4 +115,4 @@ Om inget annat anges antas samtliga beslut med enkel majoritet.
 Förslags- och rösträtt tillkommer endast sektionsmedlemmar.
 
 \subsection{Protokoll}
-Sektionsmötesprotokoll skall justeras av två av mötet valda justeringspersoner. Justerat protokoll skall korrekt anslås, enligt \ref{sec:protokoll:anslagning}, senast tio läsdagar efter mötet.
+Sektionsmötesprotokoll skall justeras av två av mötet valda justeringspersoner. Justerat protokoll skall korrekt anslås, enligt §\ref{sec:protokoll:anslagning}, senast tio läsdagar efter mötet.

--- a/stadga/sektionsmote.tex
+++ b/stadga/sektionsmote.tex
@@ -74,7 +74,7 @@ Sektionsmötet har följande åligganden:
 \subsection{Beslutförhet}
 
 \subsubsection{Beslutsmässighet}
-Sektionsmötet är beslutsmässigt om mötet är behörigt utlyst enligt §\ref{sec:utlysande}.
+Sektionsmötet är beslutsmässigt om mötet är behörigt utlyst enligt \paragraphref{sec:utlysande}.
 
 \subsubsection{Krav}
 Beslut kräver att minst x medlemmar är närvarande. \\
@@ -115,4 +115,4 @@ Om inget annat anges antas samtliga beslut med enkel majoritet.
 Förslags- och rösträtt tillkommer endast sektionsmedlemmar.
 
 \subsection{Protokoll}
-Sektionsmötesprotokoll skall justeras av två av mötet valda justeringspersoner. Justerat protokoll skall korrekt anslås, enligt §\ref{sec:protokoll:anslagning}, senast tio läsdagar efter mötet.
+Sektionsmötesprotokoll skall justeras av två av mötet valda justeringspersoner. Justerat protokoll skall korrekt anslås, enligt \paragraphref{sec:protokoll:anslagning}, senast tio läsdagar efter mötet.

--- a/stadga/sektionsstyrelse.tex
+++ b/stadga/sektionsstyrelse.tex
@@ -27,12 +27,12 @@ Sektionsstyrelsen sammanträder på kallelse av styrelsens ordförande eller vic
 Styrelsemötet är beslutsmässigt när minst hälften av medlemmarna är närvarande. Dessutom måste ordförande eller vice ordförande vara närvarande.
 
 \subsubsection{Protokoll}
-Protokoll skall föras vid styrelsemöte. Protokollet skall justeras av två medlemmar av sektionsstyrelsen och anslås korrekt, enligt §\ref{sec:protokoll:anslagning}, senast tio läsdagar efter styrelsemötet.
+Protokoll skall föras vid styrelsemöte. Protokollet skall justeras av två medlemmar av sektionsstyrelsen och anslås korrekt, enligt \paragraphref{sec:protokoll:anslagning}, senast tio läsdagar efter styrelsemötet.
 
 \subsection{Avsättning}
 
 \subsubsection{Förutsättningar}
-För att avsätta sektionsstyrelsen krävs att ärendet är korrekt anslaget enligt §\ref{sec:protokoll:anslagning} senast tre läsdagar innan sektionsmöte, samt att mötet är beslutsmässigt och minst 3/4 av de röstberättigade vid mötet är om beslutet ense. 
+För att avsätta sektionsstyrelsen krävs att ärendet är korrekt anslaget enligt \paragraphref{sec:protokoll:anslagning} senast tre läsdagar innan sektionsmöte, samt att mötet är beslutsmässigt och minst 3/4 av de röstberättigade vid mötet är om beslutet ense. 
 
 \subsubsection{Förfarande}
 Vid sådant möte skall interimsstyrelse och ny valberedning väljas. Interimsstyrelsen utfärdar kallelse till extra sektionsmöte där ny ordinarie styrelse skall väljas. Detta sektionsmöte skall hållas inom 15 läsdagar från det sektionsmöte då interimsstyrelsen valdes och under ordinarie terminstid.

--- a/stadga/sektionsstyrelse.tex
+++ b/stadga/sektionsstyrelse.tex
@@ -27,12 +27,12 @@ Sektionsstyrelsen sammanträder på kallelse av styrelsens ordförande eller vic
 Styrelsemötet är beslutsmässigt när minst hälften av medlemmarna är närvarande. Dessutom måste ordförande eller vice ordförande vara närvarande.
 
 \subsubsection{Protokoll}
-Protokoll skall föras vid styrelsemöte. Protokollet skall justeras av två medlemmar av sektionsstyrelsen och anslås korrekt, enligt \ref{sec:protokoll:anslagning}, senast tio läsdagar efter styrelsemötet.
+Protokoll skall föras vid styrelsemöte. Protokollet skall justeras av två medlemmar av sektionsstyrelsen och anslås korrekt, enligt §\ref{sec:protokoll:anslagning}, senast tio läsdagar efter styrelsemötet.
 
 \subsection{Avsättning}
 
 \subsubsection{Förutsättningar}
-För att avsätta sektionsstyrelsen krävs att ärendet är korrekt anslaget enligt \ref{sec:protokoll:anslagning} senast tre läsdagar innan sektionsmöte, samt att mötet är beslutsmässigt och minst 3/4 av de röstberättigade vid mötet är om beslutet ense. 
+För att avsätta sektionsstyrelsen krävs att ärendet är korrekt anslaget enligt §\ref{sec:protokoll:anslagning} senast tre läsdagar innan sektionsmöte, samt att mötet är beslutsmässigt och minst 3/4 av de röstberättigade vid mötet är om beslutet ense. 
 
 \subsubsection{Förfarande}
 Vid sådant möte skall interimsstyrelse och ny valberedning väljas. Interimsstyrelsen utfärdar kallelse till extra sektionsmöte där ny ordinarie styrelse skall väljas. Detta sektionsmöte skall hållas inom 15 läsdagar från det sektionsmöte då interimsstyrelsen valdes och under ordinarie terminstid.

--- a/stadga/studienamnd.tex
+++ b/stadga/studienamnd.tex
@@ -9,7 +9,7 @@ Studienämnden Informationsteknik består av ordförande, samt i reglemente fast
 Studienämnden Informationsteknik, \SNIT{}, har till uppdrag att inom teknologsektionen övervaka studiefrågor, aktivt verka för bra/bättre kurser, främja kontakten med examinatorer samt hålla god kontakt med teknologsektionens medlemmar.
 
 \subsection{Protokoll}
-Protokoll skall föras vid studienämndsmöte. Protokollet skall justeras av en studienämndsmedlem och korrekt anslås, enligt \ref{sec:protokoll:anslagning}, senast tio läsdagar efter studienämndsmötet.
+Protokoll skall föras vid studienämndsmöte. Protokollet skall justeras av en studienämndsmedlem och korrekt anslås, enligt §\ref{sec:protokoll:anslagning}, senast tio läsdagar efter studienämndsmötet.
 
 \subsection{Rättigheter}
 Studienämnd äger rätt att i namn och emblem använda teknologsektionens namn och dess symboler.

--- a/stadga/studienamnd.tex
+++ b/stadga/studienamnd.tex
@@ -9,7 +9,7 @@ Studienämnden Informationsteknik består av ordförande, samt i reglemente fast
 Studienämnden Informationsteknik, \SNIT{}, har till uppdrag att inom teknologsektionen övervaka studiefrågor, aktivt verka för bra/bättre kurser, främja kontakten med examinatorer samt hålla god kontakt med teknologsektionens medlemmar.
 
 \subsection{Protokoll}
-Protokoll skall föras vid studienämndsmöte. Protokollet skall justeras av en studienämndsmedlem och korrekt anslås, enligt §\ref{sec:protokoll:anslagning}, senast tio läsdagar efter studienämndsmötet.
+Protokoll skall föras vid studienämndsmöte. Protokollet skall justeras av en studienämndsmedlem och korrekt anslås, enligt \paragraphref{sec:protokoll:anslagning}, senast tio läsdagar efter studienämndsmötet.
 
 \subsection{Rättigheter}
 Studienämnd äger rätt att i namn och emblem använda teknologsektionens namn och dess symboler.

--- a/stadga/valberedning.tex
+++ b/stadga/valberedning.tex
@@ -13,7 +13,7 @@ Valberedningen uppdrag är att sammanställa och presentera lämpliga kandidater
 Valberedningen skall inte bereda kandidater till revisor eller efterföljande valberedning.
 
 \subsection{Anslag}
-Valberedningens nomineringar skall korrekt anslås, enligt \ref{sec:protokoll:anslagning}, minst fem läsdagar före sektionsmöte.
+Valberedningens nomineringar skall korrekt anslås, enligt §\ref{sec:protokoll:anslagning}, minst fem läsdagar före sektionsmöte.
 
 \subsection{Fri nominering}
 Fri nominering är tillåten till alla poster utom ordförande och kassör i sektionsstyrelse, studienämnd eller sektionskommittéer. Nomineringsbara till dessa poster är endast de som minst 24 timmar innan sektionsmöte då val skall ske anmält sitt intresse till sektionens valberedning.

--- a/stadga/valberedning.tex
+++ b/stadga/valberedning.tex
@@ -13,7 +13,7 @@ Valberedningen uppdrag är att sammanställa och presentera lämpliga kandidater
 Valberedningen skall inte bereda kandidater till revisor eller efterföljande valberedning.
 
 \subsection{Anslag}
-Valberedningens nomineringar skall korrekt anslås, enligt §\ref{sec:protokoll:anslagning}, minst fem läsdagar före sektionsmöte.
+Valberedningens nomineringar skall korrekt anslås, enligt \paragraphref{sec:protokoll:anslagning}, minst fem läsdagar före sektionsmöte.
 
 \subsection{Fri nominering}
 Fri nominering är tillåten till alla poster utom ordförande och kassör i sektionsstyrelse, studienämnd eller sektionskommittéer. Nomineringsbara till dessa poster är endast de som minst 24 timmar innan sektionsmöte då val skall ske anmält sitt intresse till sektionens valberedning.


### PR DESCRIPTION
What the title says. Does not seem to produce any weird characters from what I have seen.

Compiled using Arch Linux's `texlive-most` distribution of LaTeX, and by running `make` twice from the root directory.
