### PR TITLE
Fix link to dispositionsavtal

### DIFF
--- a/policies/lokalpolicy/lokalpolicy.tex
+++ b/policies/lokalpolicy/lokalpolicy.tex
@@ -43,7 +43,7 @@ Förutom IT­-sektionens egen lokalpolicy, lyder också sektionens medlemmar u
 Tekniska Högskola AB. Se nedan:
 \newline
 \MYhref{https://chalmersstudentkar.se/wp-content/uploads/2017/07/Lokalpolicy.pdf}{Kårens lokalpolicy}\\
-\MYhref{https://chalmers.it/uploads/media/2021/10/Dispositionsavtal_Hubben_2_1_2019-03-25-8e5c7d76af8.pdf}{Dispositionsavtal}
+\MYhref{https://chalmers.it/api/media/dj8HJezcQfrqZsHFjkkX212kS5SZ-5mZq0clOS58n2Y}{Dispositionsavtal}
 
 \subsection{Dokumentets Syfte}
 Följande dokument beskriver vilka riktlinjer och regler som gäller för de lokaler som nyttjas av


### PR DESCRIPTION
The current link points to the location on the old chalmers.it.
This PR changes it to point to the correct location on the new site.