### PR TITLE
Move regulations s. 1.4.1 to s. 1.5

### DIFF
--- a/reglemente/sektionsmote.tex
+++ b/reglemente/sektionsmote.tex
@@ -48,5 +48,5 @@ Bifalles yrkandet om ajournering av mötesordförande skall tidslängden av ajou
 \subsection{Interpellation}
 Sektionsorgan måste svara på interpellationer som inkommit innan sista inlämningsdagen för motioner enligt stadgarna. Om varken interpellatören eller en representant för interpellatören framför interpellationen framförs den av mötesordförande.
 
-\subsubsection{Motion}
+\subsection{Motion}
 Motion som är upptagen på dagordningen måste lyftas och föredragas av motionären eller någon annan på mötet med förslagsrätt, annars faller motionen. Sektionsstyrelsen skall lämna sitt utlåtande om motioner som inkommit innan sista inlämningsdagen för motioner enligt stadgarna.


### PR DESCRIPTION
Currently, it looks like this:
![image](https://github.com/user-attachments/assets/7d2f8a99-e1d6-4b9f-b9a3-d517e34b133f)

Which is a weird structure. Therefore the board suggests to make the editorial change to move it from s. 1.4.1 to s. 1.5.