### PR TITLE
Correct previous editorial change, make documents build again

### DIFF
--- a/.github/workflows/build_document.yml
+++ b/.github/workflows/build_document.yml
@@ -18,21 +18,18 @@ jobs:
     name: Build PDF
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Build latex
-        uses: xu-cheng/latex-action@v2
+        uses: xu-cheng/latex-action@v3
         with:
           root_file: ${{ inputs.latex_build_entry }}
-          args: -jobname=${{ inputs.document_name }}
+          args: -jobname=${{ inputs.document_name }} -output-directory=${{ github.workspace }}
           latexmk_use_xelatex: true
           work_in_root_file_dir: ${{ inputs.build_working_directory }}
-      - name: Move PDF if created in working directory
-        if: ${{ inputs.build_working_directory != '' }}
-        run: mv ${{ inputs.build_working_directory }}/${{ inputs.document_name }}.pdf ${{ inputs.document_name }}.pdf
       - name: Upload PDF
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.document_name }}
           path: ${{ inputs.document_name }}.pdf

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,13 +30,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
 
       - name: Get pdfs
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: ./pdfs
 
@@ -50,7 +50,7 @@ jobs:
           find . -not -path "./pdfs/*" -not -name "pdfs" -not -name "." -delete
 
       - name: Checkout site repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: cthit/dokument-site
           path: site
@@ -62,7 +62,7 @@ jobs:
           rm -rf pdfs
 
       - name: Install, build and upload site output
-        uses: withastro/action@v2
+        uses: withastro/action@v3
         with:
           path: site
           package-manager: pnpm@latest # Should probably be gotten from dokument-site repo instead.

--- a/reglemente/sektionsmote.tex
+++ b/reglemente/sektionsmote.tex
@@ -45,8 +45,8 @@ Reservation mot beslut av sektionsmötet skall anmälas skriftligen senast 24 ti
 \subsubsection{Ajournering}
 Bifalles yrkandet om ajournering av mötesordförande skall tidslängden av ajourneringen fastställas.
 
-\subsection{Interpellation}
+\subsubsection{Interpellation}
 Sektionsorgan måste svara på interpellationer som inkommit innan sista inlämningsdagen för motioner enligt stadgarna. Om varken interpellatören eller en representant för interpellatören framför interpellationen framförs den av mötesordförande.
 
-\subsection{Motion}
+\subsubsection{Motion}
 Motion som är upptagen på dagordningen måste lyftas och föredragas av motionären eller någon annan på mötet med förslagsrätt, annars faller motionen. Sektionsstyrelsen skall lämna sitt utlåtande om motioner som inkommit innan sista inlämningsdagen för motioner enligt stadgarna.


### PR DESCRIPTION
This PR contains an editorial change that corrects a previous change in #115 where a section was incorrectly moved out. Instead, both s. 1.4 and s. 1.5 should be moved in one level to s. 1.3.3 and s. 1.3.4 respectively, making them both fall under s. 1.3 as part of "Mötesordning".

This PR also contains action version updates to make documents build again, as well as a small simplification in the document build upload process.