### PR TITLE
Editorial: Replace arbetsmat with möteskostnader

### DIFF
--- a/policies/ekonomisk_policy/ekonomisk_policy.tex
+++ b/policies/ekonomisk_policy/ekonomisk_policy.tex
@@ -151,7 +151,7 @@ Avgången kassör ska uppvisa sin bokföring för lekmannarrevisorer varje läsp
 	\item Samtliga medlemmar i \FANBARERIT{} har rätt att få sektionens frackband och pin bekostade av sektionen.
 	\item Samtliga medlemmar i \FANBARERIT{} har, efter att ha genomfört minst ett arrangemang, rätt att var för sig få en kemtvätt av sin högtidsklädsel bekostad vid \FANBARERIT{}s verksamhetsårs slut.
         \item Samtliga arbetsgrupper har rätt till att lägga 800 kr per person på
-intern representation, arbetsmat eller profilering.
+intern representation, möteskostnader eller profilering.
 \end{itemize}
 
 \section{Aspningsbudget}


### PR DESCRIPTION
Turns out that we missed a spot. As arbetsmat doesn't exist anymore, we fill it in with the new definition of möteskostnader.

This is an editorial change, so it will be brought up on the division meeting if merged.