### PR TITLE
Fix failing publish workflow

### DIFF
--- a/.github/workflows/build_document.yml
+++ b/.github/workflows/build_document.yml
@@ -18,18 +18,18 @@ jobs:
     name: Build PDF
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: true
       - name: Build latex
-        uses: xu-cheng/latex-action@v3
+        uses: xu-cheng/latex-action@v4
         with:
           root_file: ${{ inputs.latex_build_entry }}
           args: -jobname=${{ inputs.document_name }} -output-directory=${{ github.workspace }}
           latexmk_use_xelatex: true
           work_in_root_file_dir: ${{ inputs.build_working_directory }}
       - name: Upload PDF
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.document_name }}
           path: ${{ inputs.document_name }}.pdf

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,7 +65,7 @@ jobs:
         uses: withastro/action@v6
         with:
           path: site
-          package-manager: pnpm@latest # Should probably be gotten from dokument-site repo instead.
+          package-manager: pnpm@10.34.4 # Should always match the expected version from the dokument-site repo.
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,13 +30,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Get pdfs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ./pdfs
 
@@ -50,7 +50,7 @@ jobs:
           find . -not -path "./pdfs/*" -not -name "pdfs" -not -name "." -delete
 
       - name: Checkout site repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: cthit/dokument-site
           path: site
@@ -69,4 +69,4 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,7 @@ jobs:
           rm -rf pdfs
 
       - name: Install, build and upload site output
-        uses: withastro/action@v3
+        uses: withastro/action@v6
         with:
           path: site
           package-manager: pnpm@latest # Should probably be gotten from dokument-site repo instead.


### PR DESCRIPTION
The publish workflow currently fails. See the [run below](https://github.com/cthit/dokument/actions/runs/27559679718/job/81468969625):

<img height="300" src="https://github.com/user-attachments/assets/f4e08997-17ae-42d4-8243-3ccd048657bf" />

```
warn: This version of pnpm requires at least Node.js v22.13
warn: The current version of Node.js is v20.20.2
warn: Visit https://r.pnpm.io/comp to see the list of past pnpm versions with respective Node.js version support.
node:internal/modules/cjs/loader:1031
      throw new ERR_UNKNOWN_BUILTIN_MODULE(request);
            ^

Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
```

The error is caused by trying to use the `node:sqlite` module in Node version 20, but [this was not added until Node 22](https://nodejs.org/api/sqlite.html).

This PR fixes this by updating the Astro action to v6, which uses Node 24 by default. It also updates all other actions to their respective latest versions, which means the actions are now also based on Node 24.