### PR TITLE
Update regulations revisioned date to 2026-05-19

### DIFF
--- a/reglemente/reglemente.tex
+++ b/reglemente/reglemente.tex
@@ -19,7 +19,8 @@
 %\revisioned{2025--02--27}
 %\revisioned{2025--10--09}
 %\revisioned{2025--12--11}
-\revisioned{2026--02--26}
+%\revisioned{2026--02--26}
+\revisioned{2026--05--19}
 \maketitle
 \thispagestyle{empty}
 


### PR DESCRIPTION
#129 missed updating the revisioned date in the regulations. This PR fixes that.

This is not a "redaktionell ändring" as the previous change has not been published yet due to the broken workflow (fixed in #130)